### PR TITLE
fix: read hook stdin from fd 0 for CI portability

### DIFF
--- a/hooks/scripts/post-tool-use.mjs
+++ b/hooks/scripts/post-tool-use.mjs
@@ -33,7 +33,9 @@ function isSecuritySensitiveFile(filePath) {
 
 let input = '';
 try {
-  input = readFileSync('/dev/stdin', 'utf8');
+  // Read fd 0 directly (portable across macOS and Linux CI); `/dev/stdin` can read
+  // empty when stdin is a pipe on some Linux runners.
+  input = readFileSync(0, 'utf8');
 } catch {
   process.exit(0);
 }

--- a/hooks/scripts/pre-tool-use.mjs
+++ b/hooks/scripts/pre-tool-use.mjs
@@ -23,7 +23,9 @@ process.on('unhandledRejection', failOpen);
 
 let input = '';
 try {
-  input = readFileSync('/dev/stdin', 'utf8');
+  // Read fd 0 directly. `/dev/stdin` re-opens the pipe and can read empty on Linux CI
+  // (a known gotcha); reading the fd is portable across macOS and Linux runners.
+  input = readFileSync(0, 'utf8');
 } catch {
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
Follow-up to PR #9. The lifecycle hooks read their JSON payload from `/dev/stdin`, which can read empty when stdin is a pipe on Linux CI runners — making the hook-spawning guards (`check-hook-falsepositive`, `check-utopia-guard`) fail under GitHub Actions even though they pass locally. Read fd 0 directly instead; portable across macOS and Linux, identical behavior with the real harness.

This unblocks CI on `main` (the PR #9 merge landed before this fix).

## Verification
- `npm run check:all` → PASS (7 guards) locally.
- Single-commit diff over `main` (582e737).
